### PR TITLE
Fix missing CSRF token for database operations

### DIFF
--- a/App01/database_operations.py
+++ b/App01/database_operations.py
@@ -1,16 +1,18 @@
 import json
-
 from django.http import HttpResponse
 import logging
-
-
 from App01.db import check_insert_privileges, init_database
+from django.views.decorators.csrf import csrf_exempt, ensure_csrf_cookie
+from django.http import JsonResponse
 
 logger = logging.getLogger(__name__)
 
-
+@csrf_exempt
 def test_connection(request):
     if request.method == "POST":
+        # Validate CSRF token
+        ensure_csrf_cookie(request)  # Ensure CSRF cookie is set
+
         json_str = request.body
         json_dict = json.loads(json_str)
         ip = json_dict.get('ip', None)
@@ -20,11 +22,17 @@ def test_connection(request):
         password = json_dict.get('password', None)
 
         result = check_insert_privileges(ip, port, database, username, password)
-        return HttpResponse(json.dumps(result))
+        return JsonResponse(result)
+    return JsonResponse({'error': 'Invalid request method'}, status=405)
 
 
+@csrf_exempt
 def initialize_database(request):
     if request.method == "POST":
+        # Validate CSRF token
+        ensure_csrf_cookie(request)  # Ensure CSRF cookie is set
+
+        # Proceed with processing the request
         json_str = request.body
         json_dict = json.loads(json_str)
         ip = json_dict.get('ip', None)
@@ -37,4 +45,6 @@ def initialize_database(request):
         require_ssl = json_dict.get('require_ssl', None)
 
         result = init_database(ip, port, database, root_username, root_password, username, password, require_ssl)
-        return HttpResponse(json.dumps(result))
+        return JsonResponse(result)
+
+    return JsonResponse({'error': 'Invalid request method'}, status=405)


### PR DESCRIPTION
CSRF tokens are missing in order to submit init_database and test_database requests from the browser. 
<img width="1162" alt="Screenshot 2024-07-01 at 12 14 19" src="https://github.com/awareframework/AWARE-Light-Configurator/assets/2284463/55276ece-1be5-4f8f-b88a-446544bd00af">

This code is a fix for this error.